### PR TITLE
chore: only use one package manager

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
-name: Test
+name: Contract Test
 
 on:
+  push:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
@@ -12,9 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npm install -g yarn
-      - run: yarn add ganache
-      - run: yarn add truffle
+      - run: yarn install
       - run: npx truffle version
       - name: Run Ethereum locally for test
         run: npx ganache > ganache.log &

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 ibc-solidity-contract is the EVM-compatible IBC implementation for chain based on [AXON](https://github.com/axonweb3/axon).
 
-## Contribution
+## Contract Compilation
 
-1. Installs toolchain: `npm install --save-dev truffle`
-2. Compile: `npm run compile`
+```bash
+# 1. Installs dependencies
+yarn install
+
+# 2. Compile
+yarn compile
+```
 
 ## Deployment on AXON
 
@@ -14,5 +19,4 @@ AXON_HTTP_RPC_URL=http://<Ip>:<Port>
 ```
 
 ## Deploy IBC-Solidity Handler on Axon
-Run `npm run migrate --network axon` to deploy one IBC handler which have registered one [MockClient](https://github.com/synapseweb3/ibc-solidity-contract/blob/master/contracts/clients/MockClient.sol) under id `07-axon-0` and bind one [MockModule](https://github.com/synapseweb3/ibc-solidity-contract/blob/master/contracts/apps/20-transfer/MockModule.sol) under port `mock-port-0`
-
+Run `yarn migrate` to deploy one IBC handler which has registered one [MockClient](https://github.com/synapseweb3/ibc-solidity-contract/blob/master/contracts/clients/MockClient.sol) under id `07-axon-0` and bind one [MockModule](https://github.com/synapseweb3/ibc-solidity-contract/blob/master/contracts/apps/20-transfer/MockModule.sol) under port `mock-port-0`

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "@openzeppelin/contracts": "^4.8.0",
     "dotenv": "^16.1.4",
     "ethers": "^5.7.1",
-    "ganache": "^7.8.0",
     "solidity-bytes-utils": "0.8.0",
     "solidity-rlp": "^2.0.6",
-    "solidity-stringutils": "git+https://github.com/ibc-solidity/solidity-stringutils.git#716294569dd2304ae8d81681951733542f999015",
-    "truffle": "^5.9.3"
+    "solidity-stringutils": "git+https://github.com/ibc-solidity/solidity-stringutils.git#716294569dd2304ae8d81681951733542f999015"
+  },
+  "devDependencies": {
+    "ganache": "^7.9.0",
+    "truffle": "^5.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,10 +897,10 @@
   dependencies:
     cbor "^5.2.0"
 
-"@truffle/codec@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@truffle/codec/-/codec-0.17.0.tgz#af30f4970b743a7b3a1bb199d6e56578c86bb95f"
-  integrity sha512-0Z7DQNCnvW++JuvNj35v/CuJoaFSAp7/+lXWwe+Zoe++E27V+hzRI88ZYxRJa0/q1HE81epd1r0ipqc7WBotig==
+"@truffle/codec@^0.17.1":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@truffle/codec/-/codec-0.17.1.tgz#08673f3a5a89cf2835d7e816e63fee234d6ff56d"
+  integrity sha512-f45cuhg92vM2N+ah3Bvm+uxiw/wc6a9o5gKJNqb8oMPCLYRGV4sQXTnNaAlFP1BBxFriciH3kwYt5xPrL39SgA==
   dependencies:
     "@truffle/abi-utils" "^1.0.1"
     "@truffle/compile-common" "^0.9.6"
@@ -921,14 +921,14 @@
     "@truffle/error" "^0.2.1"
     colors "1.4.0"
 
-"@truffle/config@^1.3.58":
-  version "1.3.58"
-  resolved "https://registry.yarnpkg.com/@truffle/config/-/config-1.3.58.tgz#ba5b966a84990a2ea9453ef2a586891ccd29ed7f"
-  integrity sha512-M6e7dAx6QMMskhwpqpOE4dAj72HapcMPtw/7c6bssCZd/E1quyAs/CpiYGDIxp2EuZHxW/9X16VzIac8sIOW7w==
+"@truffle/config@^1.3.59":
+  version "1.3.59"
+  resolved "https://registry.yarnpkg.com/@truffle/config/-/config-1.3.59.tgz#d2fbd0befe2580644befb90e480937d52ec1ae84"
+  integrity sha512-mZbxmBRZs1Mn2Sx0cSi5mhug02FkBEEFaNFZ3FYr1HKWuiSCqlSQygeRTzezRjK+zqGUoon/2H+bpUXLxBavJg==
   dependencies:
     "@truffle/error" "^0.2.1"
     "@truffle/events" "^0.1.24"
-    "@truffle/provider" "^0.3.10"
+    "@truffle/provider" "^0.3.11"
     conf "^10.1.2"
     debug "^4.3.1"
     find-up "^2.1.0"
@@ -955,23 +955,23 @@
   resolved "https://registry.yarnpkg.com/@truffle/dashboard-message-bus-common/-/dashboard-message-bus-common-0.1.6.tgz#53bd095d84b5913753cab7c6c78d3870b8ec2207"
   integrity sha512-93HNXILKeKgmW1YaWPdsQ55MJ0MaLzOA8kRXPnM5jF2H3KRlRxOeEg77R4YWtGH+cVZP4VYGXdpvUap/lOAnvw==
 
-"@truffle/db-loader@^0.2.31":
-  version "0.2.31"
-  resolved "https://registry.yarnpkg.com/@truffle/db-loader/-/db-loader-0.2.31.tgz#3dffbd451c2e480441d92ffc1dfd07697b8c4315"
-  integrity sha512-svvtZIvObQIk/f6uDX4qJ2ZUHwiLSAY8r7B0u2AIaRhcPEE1Mm8oEzhTPBl94YeOKi5wQm8VLiNaJle8aO6oGA==
+"@truffle/db-loader@^0.2.32":
+  version "0.2.32"
+  resolved "https://registry.yarnpkg.com/@truffle/db-loader/-/db-loader-0.2.32.tgz#1e7fd116a489e3ea49f52561720db75dbaf5b81d"
+  integrity sha512-LzADLp99ehOLwjeAUM3tv9aqqFU4Hr2uVWhpdYRnDORBY57gt0WV6mTFQzPS+vsR0cCo/czQa/YjbKWSsYExmw==
   optionalDependencies:
-    "@truffle/db" "^2.0.31"
+    "@truffle/db" "^2.0.32"
 
-"@truffle/db@^2.0.31":
-  version "2.0.31"
-  resolved "https://registry.yarnpkg.com/@truffle/db/-/db-2.0.31.tgz#2e97f1d5a6208886357d9f5ae6898f491fcfd656"
-  integrity sha512-GqY27owdCRXMMy22PvMMXdeQhvZMlui+hoPsbpTCMwIndyIJkyRYEtbAh5SiWX/vb8K73QhjeUmGACSmur7QiQ==
+"@truffle/db@^2.0.32":
+  version "2.0.32"
+  resolved "https://registry.yarnpkg.com/@truffle/db/-/db-2.0.32.tgz#fcd7c2d000f8b728ad7ce650e8cd9cbdfe3dff02"
+  integrity sha512-8aGLOCbOouNwmSMz1ML3n3mlCIUzeGx5PcERuPc7T6ucsex1+wJJ+dTby7fYWKdLgFxD16jH3VDVW6iajs/2Tg==
   dependencies:
     "@graphql-tools/delegate" "^8.4.3"
     "@graphql-tools/schema" "^8.3.1"
     "@truffle/abi-utils" "^1.0.1"
     "@truffle/code-utils" "^3.0.3"
-    "@truffle/config" "^1.3.58"
+    "@truffle/config" "^1.3.59"
     abstract-leveldown "^7.2.0"
     apollo-server "^3.11.0"
     debug "^4.3.1"
@@ -987,15 +987,15 @@
     pouchdb-find "^7.0.0"
     web3-utils "1.10.0"
 
-"@truffle/debugger@^12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@truffle/debugger/-/debugger-12.1.0.tgz#33acaea183582d2ba194b2234edff6203812cc38"
-  integrity sha512-s2SMamE4/TgpHVdbH1bEkCmeh2p/lipA5FjEB54AkfZ6rYUCQBjcS0patknb+qzBPDpQDGgH3xnGhMt7Nqbk+g==
+"@truffle/debugger@^12.1.1":
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/@truffle/debugger/-/debugger-12.1.1.tgz#818270dae3a53f1e0f5d1a80f84bb68cc309194a"
+  integrity sha512-5129FJk+06RxfbV1aHv4AhvATVELkhhtsC55WjRKoYTTKkU+bENf6GVgFyt3vuHEgh8mN/JOC5wg6ozWtoQyhg==
   dependencies:
     "@ensdomains/ensjs" "^2.1.0"
     "@truffle/abi-utils" "^1.0.1"
-    "@truffle/codec" "^0.17.0"
-    "@truffle/source-map-utils" "^1.3.116"
+    "@truffle/codec" "^0.17.1"
+    "@truffle/source-map-utils" "^1.3.117"
     bn.js "^5.1.3"
     debug "^4.3.1"
     json-pointer "^0.6.1"
@@ -1051,10 +1051,10 @@
     keccak "3.0.2"
     secp256k1 "4.0.3"
 
-"@truffle/interface-adapter@^0.5.34":
-  version "0.5.34"
-  resolved "https://registry.yarnpkg.com/@truffle/interface-adapter/-/interface-adapter-0.5.34.tgz#a45edc23d6ace0e01ebf237b668119f456729643"
-  integrity sha512-gPxabfMi2TueE4VxnNuyeudOfvGJQ1ofVC02PFw14cnRQhzH327JikjjQbZ1bT6S7kWl9H6P3hQPFeYFMHdm1g==
+"@truffle/interface-adapter@^0.5.35":
+  version "0.5.35"
+  resolved "https://registry.yarnpkg.com/@truffle/interface-adapter/-/interface-adapter-0.5.35.tgz#f0eb1c4a2803190ca249143f545029a8b641fe96"
+  integrity sha512-B5gtJnvsum5j2do393n0UfCT8MklrlAZxuqvEFBeMM9UKnreYct0/D368FVMlZwWo1N50HgGeZ0hlpSJqR/nvg==
   dependencies:
     bn.js "^5.1.3"
     ethers "^4.0.32"
@@ -1065,23 +1065,23 @@
   resolved "https://registry.yarnpkg.com/@truffle/promise-tracker/-/promise-tracker-0.1.6.tgz#daecee974e8271387031f32765a414f76e727a79"
   integrity sha512-oUZ4Mc6Yt/qTvFZ/yD4nnUIN8pXhrBN0h4/SZ4e8W1TcHNvQkV6gUkkYkn8fZRvFwTMYjvWot+eAHHNRsSl/eA==
 
-"@truffle/provider@^0.3.10":
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.3.10.tgz#d146e20f3a6facdfa1d7fbaa920dc1fca91ada39"
-  integrity sha512-oT7WKlxj1BrZBnCh9Dd4ex623yPG5ASAW5wK9kscS81MSkPYpSjld2B3tEZH9F6Lyz6lluQO1TcssuzZUek5Qg==
+"@truffle/provider@^0.3.11":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.3.11.tgz#ece46441d43db71449e1407d7b00535603213af4"
+  integrity sha512-8W7w2rcDLS/CAomTEZXzmHDgh5wQvnD0ZmTQ8Q5DktaD0z+83W8XmrSPLY3gJT7deb43ySJxEoCIj+e6+nySAw==
   dependencies:
     "@truffle/error" "^0.2.1"
-    "@truffle/interface-adapter" "^0.5.34"
+    "@truffle/interface-adapter" "^0.5.35"
     debug "^4.3.1"
     web3 "1.10.0"
 
-"@truffle/source-map-utils@^1.3.116":
-  version "1.3.116"
-  resolved "https://registry.yarnpkg.com/@truffle/source-map-utils/-/source-map-utils-1.3.116.tgz#3ce910cc671b5f5dd174dcad572e347dc2ea315c"
-  integrity sha512-53+DWPKbwPZ43p1o2Qy8C7jfcItHmRB0bT30jWkRK9ciOoM4EwbLOBk12oVzD8hRF9amQ0HElMQuKeoka+n+PA==
+"@truffle/source-map-utils@^1.3.117":
+  version "1.3.117"
+  resolved "https://registry.yarnpkg.com/@truffle/source-map-utils/-/source-map-utils-1.3.117.tgz#d46ca68cd0df7c42ba6f5ceb6dffc8ceecd68ea9"
+  integrity sha512-olToMrN+t+nIIlSwiq9rIYU36CkgQw1mcMCPmYPATJRIF+b+mcb318eYEEBSdc4vzs2FXevPojD9Nm7NNTTzxA==
   dependencies:
     "@truffle/code-utils" "^3.0.3"
-    "@truffle/codec" "^0.17.0"
+    "@truffle/codec" "^0.17.1"
     debug "^4.3.1"
     json-pointer "^0.6.1"
     node-interval-tree "^1.3.3"
@@ -3271,28 +3271,7 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
 
-ganache@7.8.0:
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/ganache/-/ganache-7.8.0.tgz#02154384f246b66e98974cbcbb18e8372df3c2e0"
-  integrity sha512-IrUYvsaE/m2/NaVIZ7D/gCnsmyU/buechnH6MhUipzG1qJcZIwIp/DoP/LZUcHyhy0Bv0NKZD2pGOjpRhn7l7A==
-  dependencies:
-    "@trufflesuite/bigint-buffer" "1.1.10"
-    "@trufflesuite/uws-js-unofficial" "20.10.0-unofficial.2"
-    "@types/bn.js" "^5.1.0"
-    "@types/lru-cache" "5.1.1"
-    "@types/seedrandom" "3.0.1"
-    abstract-level "1.0.3"
-    abstract-leveldown "7.2.0"
-    async-eventemitter "0.2.4"
-    emittery "0.10.0"
-    keccak "3.0.2"
-    leveldown "6.1.0"
-    secp256k1 "4.0.3"
-  optionalDependencies:
-    bufferutil "4.0.5"
-    utf-8-validate "5.0.7"
-
-ganache@^7.8.0:
+ganache@7.9.0, ganache@^7.9.0:
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/ganache/-/ganache-7.9.0.tgz#561deceb376b1c4e8998ac8e5a842574507d3295"
   integrity sha512-KdsTZaAKqDXTNDMKnLzg0ngX8wnZKyVGm7HD03GIyUMVRuXI83s0CUEaGIDWRUWTQP7BE8sDh7QtbW+NoX4zrQ==
@@ -5970,19 +5949,19 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-truffle@^5.9.3:
-  version "5.10.2"
-  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.10.2.tgz#67dc7377e5c8afe0f9ea7d44ac65087a185af392"
-  integrity sha512-NwcQ49MHv/qegi6YVEH3PSPcaRjf4zDmYw5G7o4IBRjBzkhX9uE0LX0R1FU+aCGhhnLQCmPrUiZnQHsAD9dJUg==
+truffle@^5.11.1:
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/truffle/-/truffle-5.11.1.tgz#08a7262477cae5b6ba06b35c5dfc5271a1c3d85a"
+  integrity sha512-8n1RQNxHUkYDGI9OXdrrFcTL810aUbMEG7rzhbU4a6n2U5xbIDrWThJTzyfoNDtEPOA7DpAYdUpHG4V14Ct0IA==
   dependencies:
-    "@truffle/db-loader" "^0.2.31"
-    "@truffle/debugger" "^12.1.0"
+    "@truffle/db-loader" "^0.2.32"
+    "@truffle/debugger" "^12.1.1"
     app-module-path "^2.2.0"
-    ganache "7.8.0"
+    ganache "7.9.0"
     mocha "10.1.0"
     original-require "^1.0.1"
   optionalDependencies:
-    "@truffle/db" "^2.0.31"
+    "@truffle/db" "^2.0.32"
 
 tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0:
   version "2.6.0"


### PR DESCRIPTION
## Changes

- npm -> yarn
- add `ganache` and `truffle` into the devDependencies of package.json

## Test
- https://github.com/synapseweb3/ibc-solidity-contract/actions/runs/5689297847/job/15420550825#step:7:1